### PR TITLE
XFS support: hint filesystem about expected maximum size of image file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,3 @@ after_success:
 # Don't bug people yet
 notifications:
   email: false
-# bmap-tools at the moment can't run on xfs inside docker container
-sudo: required
-dist: trusty

--- a/bmaptools/BmapCopy.py
+++ b/bmaptools/BmapCopy.py
@@ -555,6 +555,15 @@ class BmapCopy(object):
         self._progress_index = 0
         self._progress_time = datetime.datetime.now()
 
+        if self.image_size and self._dest_is_regfile:
+            # If we already know image size, make sure that destination file
+            # has the same size as the image
+            try:
+                os.ftruncate(self._f_dest.fileno(), self.image_size)
+            except OSError as err:
+                raise Error("cannot truncate file '%s': %s"
+                            % (self._dest_path, err))
+
         # Read the image in '_batch_blocks' chunks and write them to the
         # destination file
         while True:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -40,7 +40,7 @@ def _create_random_sparse_file(file_obj, size):
          'Filemap.get_unmapped_ranges()'
     """
 
-    file_obj.truncate(0)
+    file_obj.truncate(size)
     block_size = BmapHelpers.get_block_size(file_obj)
     blocks_cnt = (size + block_size - 1) / block_size
 
@@ -60,8 +60,6 @@ def _create_random_sparse_file(file_obj, size):
             assert seek + write <= block_size
             file_obj.seek(block * block_size + seek)
             file_obj.write(chr(random.getrandbits(8)) * write)
-        else:
-            file_obj.truncate(block * block_size)
 
         return map_the_block
 


### PR DESCRIPTION
XFS has feature about speculative pre-allocation of blocks based on
amount information written in the end of open file. In case of sparse
files it might lead to more mapped blocks than really expected.
Thus, truncate to desired size destination file as early as possible
and then write blocks that should be mapped the middle of it.

Closes #6

Signed-off-by: Alexander D. Kanevskiy <kad@kad.name>