### PR TITLE
get_block_size: if we can't get from ioctl, try from os.stat()

### DIFF
--- a/bmaptools/BmapHelpers.py
+++ b/bmaptools/BmapHelpers.py
@@ -61,7 +61,15 @@ def get_block_size(file_obj):
     # Get the block size of the host file-system for the image file by calling
     # the FIGETBSZ ioctl (number 2).
     binary_data = ioctl(file_obj, 2, struct.pack('I', 0))
-    return struct.unpack('I', binary_data)[0]
+    bsize = struct.unpack('I', binary_data)[0]
+    if not bsize:
+        import os
+        stat = os.fstat(file_obj.fileno())
+        if hasattr(stat, 'st_blksize'):
+            bsize = stat.st_blksize
+        else:
+            raise IOError("Unable to determine block size")
+    return bsize
 
 
 def program_is_available(name):


### PR DESCRIPTION
Under some conditions, ioctl FIGETBSZ can't return real value.
We can try to use fallback via os.stat() to get block size.

Closes #15

Signed-off-by: Alexander D. Kanevskiy <kad@kad.name>