### PR TITLE
TransRead: support zip compressed images

### DIFF
--- a/bmaptools/TransRead.py
+++ b/bmaptools/TransRead.py
@@ -21,7 +21,7 @@ them on-the-fly if needed. Remote files are read using urllib2 (except of
 'bz2', 'gz', 'xz', 'lzo' and a "tar" version of them: 'tar.bz2', 'tbz2', 'tbz',
 'tb2', 'tar.gz', 'tgz', 'tar.xz', 'txz', 'tar.lzo', 'tzo'. This module uses
 the following system programs for decompressing: pbzip2, bzip2, gzip, pigz, xz,
-lzop, and tar.
+lzop, tar and unzip.
 """
 
 import os
@@ -50,7 +50,7 @@ _log = logging.getLogger(__name__)  # pylint: disable=C0103
 
 # A list of supported compression types
 SUPPORTED_COMPRESSION_TYPES = ('bz2', 'gz', 'xz', 'lzo', 'tar.gz', 'tar.bz2',
-                               'tar.xz', 'tar.lzo')
+                               'tar.xz', 'tar.lzo', 'zip')
 
 
 def _fake_seek_forward(file_obj, cur_pos, offset, whence=os.SEEK_SET):
@@ -326,6 +326,10 @@ class TransRead(object):
             else:
                 archiver = "tar"
                 args = "-x --lzo -O"
+        elif self.name.endswith(".zip"):
+            self.compression_type = 'zip'
+            decompressor = "funzip"
+            args = ""
         else:
             if not self.is_url:
                 self.size = os.fstat(self._f_objs[-1].fileno()).st_size

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,8 @@ Depends: python (>=2.7),
 	 pigz,
 	 lzop,
 	 xz-utils,
-	 tar
+	 tar,
+	 unzip
 Description: Tools to generate block map (AKA bmap) and flash images using
  bmap. Bmaptool is a generic tool for creating the block map (bmap) for a file,
  and copying files using the block map. The idea is that large file containing

--- a/packaging/bmap-tools.spec
+++ b/packaging/bmap-tools.spec
@@ -15,7 +15,7 @@ Release: %{rc_str}.0.0
 Group: Development/Tools/Other
 License: GPL-2.0
 BuildArch: noarch
-URL: http://www.tizen.org
+URL: https://github.com/01org/bmap-tools
 Source0: %{name}_%{version}.tar.gz
 
 Requires: bzip2
@@ -23,6 +23,7 @@ Requires: pbzip2
 Requires: gzip
 Requires: xz
 Requires: tar
+Requires: unzip
 %if ! 0%{?tizen_version:1}
 # pigz is not present in Tizen
 Requires: pigz

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -94,7 +94,8 @@ def _generate_compressed_files(file_path, delete=True):
                    ("bzip2", "tar", ".tar.bz2", "-c -j -O -P -C /"),
                    ("gzip",  "tar", ".tar.gz",  "-c -z -O -P -C /"),
                    ("xz",    "tar", ".tar.xz",  "-c -J -O -P -C /"),
-                   ("lzop",  "tar", ".tar.lzo", "-c --lzo -O -P -C /")]
+                   ("lzop",  "tar", ".tar.lzo", "-c --lzo -O -P -C /"),
+                   ("zip",   None,  ".zip",     "-q -j -")]
 
     for decompressor, archiver, suffix, options in compressors:
         if not BmapHelpers.program_is_available(decompressor):


### PR DESCRIPTION
Some projects ship images compressed with zip, for cross OS
compatibility. Support read from such archives, assuming that
image is the first file in that archive. This is same assumption
as in case of tar.gz format.

Closes #10

Signed-off-by: Alexander D. Kanevskiy <kad@kad.name>