### PR TITLE
Add support for lz4 compression in .lz4, .tar.lz4 and .tlz4 files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,17 @@ after_success:
 # Don't bug people yet
 notifications:
   email: false
+
+# Perform testing also using optional compressors
+sudo: required
+dist: trusty
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y pbzip2 pigz lzop liblz4-tool
+# addons:
+#   apt:
+#     packages:
+#     - pbzip2
+#     - pigz
+#     - lzop
+#     - liblz4-tool

--- a/bmaptools/TransRead.py
+++ b/bmaptools/TransRead.py
@@ -19,9 +19,9 @@ This module allows opening and reading local and remote files and decompress
 them on-the-fly if needed. Remote files are read using urllib2 (except of
 "ssh://" URLs, which are handled differently). Supported file extentions are:
 'bz2', 'gz', 'xz', 'lzo' and a "tar" version of them: 'tar.bz2', 'tbz2', 'tbz',
-'tb2', 'tar.gz', 'tgz', 'tar.xz', 'txz', 'tar.lzo', 'tzo'. This module uses
-the following system programs for decompressing: pbzip2, bzip2, gzip, pigz, xz,
-lzop, tar and unzip.
+'tb2', 'tar.gz', 'tgz', 'tar.xz', 'txz', 'tar.lzo', 'tzo'. 'tar.lz4', 'tlz4'.
+This module uses the following system programs for decompressing: pbzip2, bzip2,
+gzip, pigz, xz, lzop, lz4, tar and unzip.
 """
 
 import os
@@ -49,8 +49,8 @@ _log = logging.getLogger(__name__)  # pylint: disable=C0103
 # pylint: disable=R0915
 
 # A list of supported compression types
-SUPPORTED_COMPRESSION_TYPES = ('bz2', 'gz', 'xz', 'lzo', 'tar.gz', 'tar.bz2',
-                               'tar.xz', 'tar.lzo', 'zip')
+SUPPORTED_COMPRESSION_TYPES = ('bz2', 'gz', 'xz', 'lzo', 'lz4', 'tar.gz',
+                               'tar.bz2', 'tar.xz', 'tar.lzo')
 
 
 def _fake_seek_forward(file_obj, cur_pos, offset, whence=os.SEEK_SET):
@@ -245,6 +245,12 @@ class TransRead(object):
                 return True
             return False
 
+        def is_lz4(name):
+            """Returns 'True' if file 'name' is compressed with 'lz4'."""
+            if name.endswith('.lz4') and not name.endswith('.tar.lz4'):
+                return True
+            return False
+
         def is_tar_gz(name):
             """
             Returns 'True' if file 'name' is a tar archive compressed with
@@ -282,6 +288,16 @@ class TransRead(object):
             """
 
             if name.endswith('.tar.lzo') or name.endswith('.tzo'):
+                return True
+            return False
+
+        def is_tar_lz4(name):
+            """
+            Returns 'True' if file 'name' is a tar archive compressed with
+            'lz4'.
+            """
+
+            if name.endswith('.tar.lz4') or name.endswith('.tlz4'):
                 return True
             return False
 
@@ -330,6 +346,14 @@ class TransRead(object):
             self.compression_type = 'zip'
             decompressor = "funzip"
             args = ""
+        elif is_tar_lz4(self.name) or is_lz4(self.name):
+            self.compression_type = 'lz4'
+            decompressor = "lz4"
+            if is_lz4(self.name):
+                args = "-d -c"
+            else:
+                archiver = "tar"
+                args = "-x -Ilz4 -O"
         else:
             if not self.is_url:
                 self.size = os.fstat(self._f_objs[-1].fileno()).st_size

--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Depends: python (>=2.7),
 	 gzip,
 	 pigz,
 	 lzop,
+	 liblz4-tool,
 	 xz-utils,
 	 tar,
 	 unzip

--- a/docs/man1/bmaptool.1
+++ b/docs/man1/bmaptool.1
@@ -112,6 +112,9 @@ extensions are supported:
 .RS 4
 4. ".lzo", "tar.lzo", ".tzo" for files and tar archives compressed with "\fIlzo\fR" program
 .RE
+.RS 4
+4. ".lz4", "tar.lz4", ".tlz4" for files and tar archives compressed with "\fIlz4\fR" program
+.RE
 
 .PP
 IMAGE files with other extensions are assumed to be uncompressed. Note,

--- a/tests/test_api_base.py
+++ b/tests/test_api_base.py
@@ -89,12 +89,14 @@ def _generate_compressed_files(file_path, delete=True):
                    ("pigz",   None, ".p.gz",  "-c -k"),
                    ("xz",     None, ".xz",    "-c -k"),
                    ("lzop",   None, ".lzo",   "-c -k"),
+                   ("lz4",   None, ".lz4",   "-c -k"),
                    # The "-P -C /" trick is used to avoid silly warnings:
                    # "tar: Removing leading `/' from member names"
                    ("bzip2", "tar", ".tar.bz2", "-c -j -O -P -C /"),
                    ("gzip",  "tar", ".tar.gz",  "-c -z -O -P -C /"),
                    ("xz",    "tar", ".tar.xz",  "-c -J -O -P -C /"),
                    ("lzop",  "tar", ".tar.lzo", "-c --lzo -O -P -C /"),
+                   ("lz4",  "tar", ".tar.lz4", "-c -Ilz4 -O -P -C /"),
                    ("zip",   None,  ".zip",     "-q -j -")]
 
     for decompressor, archiver, suffix, options in compressors:


### PR DESCRIPTION
- lz4 is a fast compression algo, usually comparable to lzo, "lz4" is the tool available on most distros for it.

- Following files might also need changes, but not sure if I should be doing that:

  - docs/RELEASE_NOTES
  - debian/changelog
  - debian/control
  - packaging/bmap-tools.spec
  - packaging/bmap-tools.changes

  Let me know if I should update these as well.
  Don't really have dpkg/rpm setup to test these, but changes should be rather trivial.

- Basic approach for adding the feature was to `grep -ri lzo *` and copy-paste these blocks for lz4, as it has exactly same interface for cli tool (checked).

- tar doesn't have `--lz4` option, but `-Ilz4` works, as again, same cli as with all compression binaries.

- Both nose tests and actual copy from .lz4 seem to succeed.

- You've probably also received same [PATCH] from ML, probably easier to work with it here and ignore that one.
