### PR TITLE
TransRead: Fix differentiating between local files and urllib

### DIFF
--- a/bmaptools/TransRead.py
+++ b/bmaptools/TransRead.py
@@ -376,7 +376,7 @@ class TransRead(object):
         else:
             args = decompressor + " " + args
 
-        if hasattr(self._f_objs[-1], 'fileno'):
+        if type(self._f_objs[-1]) == file:
             child_stdin = self._f_objs[-1].fileno()
         else:
             child_stdin = subprocess.PIPE


### PR DESCRIPTION
Commit 6343239fb was meant to take a different code path for urllib
downloads and local files, however the check to differentiate between
the two as broken as it turns out urllib objects also have fileno
attributes.

Fix this by specifically checking the object type and only then take the
direct codepath. This resolved bmaptool copy failing when using urls
instead of local files.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>